### PR TITLE
SIMPLY-3259: Open eBooks: Accounts Button

### DIFF
--- a/app/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
+++ b/app/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
@@ -25,4 +25,6 @@ class OEIBuildConfigurationService : BuildConfigurationServiceType {
     true
   override val allowAccountsRegistryAccess: Boolean =
     false
+  override val showChangeAccountsUi: Boolean =
+    false
 }


### PR DESCRIPTION
**What's this do?**
Here the `showChangeAccountsUi` attribute is used from `BuildConfigurationAccountsType` to allow for the hiding of the change account option on the Catalog screen.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-3259: Open eBooks: Accounts Button](https://jira.nypl.org/browse/SIMPLY-3259)

**How should this be tested? / Do these changes have associated tests?**
Toggle the `showChangeAccountsUi` attribute true/false to see if the change account screen his hidden/shown on the Catalog screen in `OEIBuildConfigurationService`.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 
