### PR TITLE
v4.0.0-beta002

### DIFF
--- a/app/version.properties
+++ b/app/version.properties
@@ -1,4 +1,4 @@
 #
-#Tue Nov 17 11:59:02 CST 2020
-versionName=4.0.0-beta001
-versionCode=4073
+#Sat Nov 21 19:29:21 CST 2020
+versionName=4.0.0-beta002
+versionCode=4085

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
   }
 
   nyplFindawayVersion = "5.0.0"
-  simplifiedVersion = "6.2.0"
+  simplifiedVersion = "6.4.0"
   firebaseVersion = "17.2.2"
 }
 


### PR DESCRIPTION
**What's this do?**
This is an updated QA release of Open eBooks release blockers.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-3257: Open eBooks: App Icon (Android)](https://jira.nypl.org/browse/SIMPLY-3257)
[SIMPLY-3259: Open eBooks: Accounts Button (Android)]( https://jira.nypl.org/browse/SIMPLY-3259)

**How should this be tested? / Do these changes have associated tests?**
Download app, examine catalog screen and app icon.

**Dependencies for merging? Releasing to production?**
Currently this build is using `6.4.0-SNAPSHOT`. `6.4.0` is either failing or not appearing in Maven Central.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly ran Open eBooks, it is also available in Firebase
